### PR TITLE
Custom success flash messages

### DIFF
--- a/EventListener/FlashListener.php
+++ b/EventListener/FlashListener.php
@@ -27,7 +27,7 @@ class FlashListener implements EventSubscriberInterface
     /**
      * @var array
      */
-    private static $messages = array(
+    public $messages = array(
         SyliusCartEvents::CART_SAVE_COMPLETED    => 'The cart have been updated correctly.',
         SyliusCartEvents::CART_CLEAR_COMPLETED   => 'The cart has been successfully cleared.',
 
@@ -67,11 +67,11 @@ class FlashListener implements EventSubscriberInterface
 
     public function addErrorFlash(Event $event)
     {
-        $this->session->getFlashBag()->add('error', $event->getMessage() ?: self::$messages[$event->getName()]);
+        $this->session->getFlashBag()->add('error', $event->getMessage() ?: $this->messages[$event->getName()]);
     }
 
     public function addSuccessFlash(Event $event)
     {
-        $this->session->getFlashBag()->add('success', $event->getMessage() ?: self::$messages[$event->getName()]);
+        $this->session->getFlashBag()->add('success', $event->getMessage() ?: $this->messages[$event->getName()]);
     }
 }

--- a/spec/Sylius/Bundle/CartBundle/EventListener/FlashListener.php
+++ b/spec/Sylius/Bundle/CartBundle/EventListener/FlashListener.php
@@ -12,6 +12,7 @@
 namespace spec\Sylius\Bundle\CartBundle\EventListener;
 
 use PHPSpec2\ObjectBehavior;
+use Sylius\Bundle\CartBundle\SyliusCartEvents;
 
 /**
  * Flash message listener spec.
@@ -20,6 +21,7 @@ use PHPSpec2\ObjectBehavior;
  */
 class FlashListener extends ObjectBehavior
 {
+
     /**
      * @param Symfony\Component\HttpFoundation\Session\SessionInterface $session
      */
@@ -31,5 +33,145 @@ class FlashListener extends ObjectBehavior
     function it_is_initializable()
     {
         $this->shouldHaveType('Sylius\Bundle\CartBundle\EventListener\FlashListener');
+    }
+
+    /**
+     * @param Symfony\Component\EventDispatcher\Event $event
+     * @param Symfony\Component\HttpFoundation\Session\Flash\FlashBag $flashBag
+     */
+    function it_should_add_a_custom_error_flash_message_from_event($session, $event, $flashBag)
+    {
+
+        $message = "This is an error message";
+
+        $event
+            ->getMessage()
+            ->shouldBeCalled()
+            ->willReturn($message)
+        ;
+
+        $session
+            ->getFlashBag()
+            ->shouldBeCalled()
+            ->willReturn($flashBag)
+        ;
+
+        $flashBag
+            ->add('error', $message)
+            ->shouldBeCalled()
+            ->willReturn(null)
+        ;
+
+        $this
+            ->addErrorFlash($event)
+        ;
+    }
+
+    /**
+     * @param Symfony\Component\EventDispatcher\Event $event
+     * @param Symfony\Component\HttpFoundation\Session\Flash\FlashBag $flashBag
+     */
+    function it_should_add_a_custom_success_flash_message_from_event($session, $event, $flashBag)
+    {
+
+        $message = "This is an success message";
+
+        $event
+            ->getMessage()
+            ->shouldBeCalled()
+            ->willReturn($message)
+        ;
+
+        $session
+            ->getFlashBag()
+            ->shouldBeCalled()
+            ->willReturn($flashBag)
+        ;
+
+        $flashBag
+            ->add('success', $message)
+            ->shouldBeCalled()
+            ->willReturn(null)
+        ;
+
+        $this
+            ->addSuccessFlash($event)
+        ;
+    }
+
+    /**
+     * @param Symfony\Component\EventDispatcher\Event $event
+     * @param Symfony\Component\HttpFoundation\Session\Flash\FlashBag $flashBag
+     */
+    function it_should_have_a_default_error_flash_message_for_event_name($session, $event, $flashBag, $cartEvents)
+    {
+        $messages = array(SyliusCartEvents::ITEM_ADD_ERROR => 'Error occurred while adding item to cart.');
+        $this->getWrappedSubject()->messages = $messages;
+
+        $event
+            ->getName()
+            ->shouldBeCalled()
+            ->willReturn(SyliusCartEvents::ITEM_ADD_ERROR)
+        ;
+
+        $event
+            ->getMessage()
+            ->shouldBeCalled()
+            ->willReturn(null)
+        ;
+
+        $session
+            ->getFlashBag()
+            ->shouldBeCalled()
+            ->willReturn($flashBag)
+        ;
+
+        $flashBag
+            ->add('error', $messages[SyliusCartEvents::ITEM_ADD_ERROR])
+            ->shouldBeCalled()
+            ->willReturn(null)
+        ;
+
+        $this
+            ->addErrorFlash($event)
+        ;
+    }
+
+    /**
+     * @param Symfony\Component\EventDispatcher\Event $event
+     * @param Symfony\Component\HttpFoundation\Session\Flash\FlashBag $flashBag
+     */
+    function it_should_have_a_default_success_flash_message_for_event_name($session, $event, $flashBag, $cartEvents)
+    {
+        $messages = array(SyliusCartEvents::ITEM_ADD_COMPLETED => 'The cart have been updated correctly.');
+        $this->getWrappedSubject()->messages = $messages;
+
+        $event
+            ->getName()
+            ->shouldBeCalled()
+            ->willReturn(SyliusCartEvents::ITEM_ADD_COMPLETED)
+        ;
+
+        $event
+            ->getMessage()
+            ->shouldBeCalled()
+            ->willReturn(null)
+        ;
+
+        $session
+            ->getFlashBag()
+            ->shouldBeCalled()
+            ->willReturn($flashBag)
+        ;
+
+        $flashBag
+            ->add('error', $messages[SyliusCartEvents::ITEM_ADD_COMPLETED])
+            ->shouldBeCalled()
+            ->willReturn(null)
+        ;
+
+        $this
+            ->addErrorFlash($event)
+        ;
     }
 }


### PR DESCRIPTION
Added support for custom 'success' flash messages when adding or modifying the cart, such as "2 items added to the cart".
