### PR TITLE
Fixed transitive association persistence issue (Issue #48)

### DIFF
--- a/EventListener/CartListener.php
+++ b/EventListener/CartListener.php
@@ -113,7 +113,7 @@ class CartListener implements EventSubscriberInterface
 
         if ($valid) {
             $this->cartManager->persist($cart);
-            $this->cartManager->flush($cart);
+            $this->cartManager->flush();
             $this->cartProvider->setCart($cart);
         }
     }
@@ -130,6 +130,7 @@ class CartListener implements EventSubscriberInterface
         $totalQuantity = 0;
         foreach ($cart->getItems() as $item) {
             $totalQuantity += $item->getQuantity();
+            $this->cartManager->persist($item);
         }
         $cart->setTotalQuantity($totalQuantity);
     }


### PR DESCRIPTION
Solution to Issue #48 - "Incorrect quantity when adding the same product on dev-master". 

The changes made to the cart's item collection happen on the inverse side of the relationship, according to doctrine "Changes made only to the inverse side of an association are ignored. Make sure to update both sides of a bidirectional association (or at least the owning side, from Doctrine’s point of view)". 

Solution is to explicitly persist the items in the refreshCart function. More info at http://docs.doctrine-project.org/en/latest/reference/unitofwork-associations.html
