### PR TITLE
[PoC] Travis CI: Execute Behat scenarios of Sylius framework repo in a Sylius bundle repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,23 @@ matrix:
     allow_failure:
         - php: 5.5
 
-before_script: composer install --dev --prefer-source > /dev/null
+before_script:
+    - composer install --dev --prefer-source > /dev/null
+    - composer create-project sylius/sylius -s dev --dev --prefer-source --no-interaction > /dev/null
+    - cd sylius
+    - composer require sylius/cart-bundle:dev-master > /dev/null
+    - app/console doctrine:database:create --env=test > /dev/null
+    - app/console doctrine:schema:create --env=test > /dev/null
+    - chmod -R 777 app/cache app/logs
+    - app/console cache:warmup --env=test > /dev/null
+    - chmod -R 777 app/cache app/logs
+    - cd ..
 
-script: bin/phpspec run -fpretty --verbose
+script:
+    - bin/phpspec run -fpretty --verbose
+    - cd sylius
+    - php -d memory_limit=2048M bin/behat --no-snippets --no-paths --verbose --tags '@cart'
 
-notifications:
-    email: "travis-ci@sylius.org"
-    irc:   "irc.freenode.org#sylius-dev"
+#notifications:
+#    email: "travis-ci@sylius.org"
+#    irc: "irc.freenode.org#sylius-dev"


### PR DESCRIPTION
https://github.com/headrevision/SyliusCartBundle/blob/travis-with-sylius-behat/.travis.yml demonstrates how those Behat scenarios in https://github.com/Sylius/Sylius/tree/master/features can be executed which are related to the behavior of a particular Sylius bundle. In the case of this bundle, SyliusCartBundle, those are at least the scenarios/features tagged with `@cart`. For the Behat execution the Sylius framework is installed with the `dev-master` version of composer package `sylius/cart-bundle`, ie. a fresh clone of the SyliusCartBundle repo. Thus, immediate CI of your code changes to the bundle at application level is facilitated. Furthermore, you could think about excluding the execution of the `@cart`-tagged (the bundle-related) scenarios in https://github.com/Sylius/Sylius/blob/master/.travis.yml to speed up the execution of Sylius' Behat suite, which takes enormously long so far (see https://github.com/Sylius/Sylius/issues/254).
