### PR TITLE
replaces broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ $ bin/phpspec run -f pretty
 Documentation
 -------------
 
-Documentation is available on [**docs.sylius.org**](http://docs.sylius.org/en/latest/bundles/SyliusCartBundle/index.html).
+Documentation is available on [**docs.sylius.org**](http://docs.sylius.org).
 
 Contributing
 ------------


### PR DESCRIPTION
There seems to be no docs-page for the SyliusCartBundle right now, so I replaced the dead link to a link to the general docs site.